### PR TITLE
remove console.error from mirror client. Downstream consumers can log…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lworks-client",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "",
   "main": "dist/index.js",
   "repository": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,7 @@
 import { Environment } from "./environment";
 import { Network } from "./networks";
 
-export const libraryVersion = "2.9.0";
+export const libraryVersion = "2.9.1";
 
 type Config = {
   disableTracking: boolean;

--- a/src/mirror-client.ts
+++ b/src/mirror-client.ts
@@ -104,7 +104,6 @@ async function get<T>(endpoint: string, config: MirrorConfig): Promise<T> {
       { retries: 4 }
     );
   } catch (err) {
-    console.error(err);
     track("Failed Mirror Call", accessToken, {
       timeElapsed: timeElapsed(startAt),
       url,


### PR DESCRIPTION
… what they want to