### PR TITLE
DEV-1956 - major version bump to account for types moving around in a breaking-change sort of way

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lworks-client",
-  "version": "2.14.0",
+  "version": "3.0.0",
   "description": "",
   "main": "dist/index.js",
   "repository": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,7 @@
 import { Environment } from "./environment";
 import { Network } from "./networks";
 
-export const libraryVersion = "2.14.0";
+export const libraryVersion = "3.0.0";
 
 type Config = {
   disableTracking: boolean;


### PR DESCRIPTION
Release 2.14.0 was a lie. That was a breaking change so should've been a major version bump. I lack discipline