### PR TITLE
DEV-2007 - bring back the sentinel tests so we can troubleshoot

### DIFF
--- a/src/__tests__/sentinel-client.test.ts
+++ b/src/__tests__/sentinel-client.test.ts
@@ -44,7 +44,7 @@ async function deleteRulesForNetwork(network: "mainnet" | "testnet") {
 }
 
 jest.setTimeout(30_000);
-describe.skip("sentinel client", () => {
+describe("sentinel client", () => {
   afterAll(async () => {
     await Promise.all([deleteRulesForNetwork("mainnet"), deleteRulesForNetwork("testnet")]);
   });


### PR DESCRIPTION
I needed to merge to work on more important stuff, but don't leave the Sentinel tests skipped so we can come back and figure out what is actually happening there